### PR TITLE
feat(router,a11y): set up SPA shell w/ History API, focus mgmt & scroll restoration

### DIFF
--- a/frontend_jason/index.html
+++ b/frontend_jason/index.html
@@ -1,12 +1,45 @@
+<!-- HTML5 Document-->
 <!doctype html>
-<html lang="ko">
+
+<!-- Main language: English -->
+<html lang="en">
 	<head>
+		<!-- Character incoding option: supprots various languages and Emoji -->
 		<meta charset="UTF-8" />
+
+		<!-- Viewport settings for responsive design -->
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
-    	<title>MVP</title>
+    	<title>TEAM.Shirt</title>
 	</head>
+
+	<!-- main container
+		min-h-scrren: minimun height of viewport
+		bg-slate-50: light grey color 
+	-->
 	<body class="min-h-screen bg-slate-50">
-		<div id="app" tabindex="-1" class="outline-none"></div>
+		<!-- Skip link
+		 	Jump to the main directory
+			to where: 'app'
+			sr-only: hide on the scrren but screen reader can read it.
+		-->
+		<a href="#app" class="sr-only focus:not-sr-only absolute left-2 top-2 p-2 bg-white rounded shadow">
+			Skip to main content
+		</a>
+
+		<!-- Main container
+			focus_visible - TailwindCSS utility class.	
+				focus_visible: outline				키보드 포커스 시 윤곽선 표시
+				focus_visible: outline-2			윤곽선 두께 2px 설정
+				focus_visible: outline-offset-4		경께로부터 4px 떨어지도록 요소 설정
+				focus_visible: outline-indigo-500	윤곽선 색상 인디고(500) 설정
+		-->
+		<main
+			id="app"
+			tabindex="-1"
+			class="min-h-screen focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-indigo-500">
+		</main>
+
+		<!-- Entry point script (TypeScript, using ES module) -->
 		<script type="module" src="/src/main.ts"></script>
 	</body>
 </html>

--- a/frontend_jason/postcss.config.js
+++ b/frontend_jason/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
     tailwindcss: {},
-    // autoprefixer: {}   // MVP면 굳이 안 써도 됨
+    autoprefixer: {}   // MVP면 굳이 안 써도 됨
   },
 };

--- a/frontend_jason/readme.md
+++ b/frontend_jason/readme.md
@@ -1,35 +1,49 @@
 # Frontend Specification
 
+## ✅ What it is
+- Single File Components? Nope.
+- React/Vue? Nope.
+- This is a minimal, production-leaning Vanilla TypeScript SPA with History API routing, a11y focus management, simple store/guards, 2D Canvas renderer stub, and Tailwind CSS — matching your spec.
+
 ## ✅ Architecture
-- **Run-time**: SPA (Single Page Application)  
+- **Run-time**: SPA (Single Page Application): Responsive Design
 - **Language**: TypeScript  
 - **Framework**: None (custom router / store implementation)  
 - **UI**: Tailwind CSS  
-- **3D**: Babylon.js  
+- **3D**: Babylon.js
 
 ## ✅ UI Page Structure (Essential)
 
 ### (0) Common
 - **AppShell**  
-  - Header (Logo / Current User / Setting)  
-  - Main container  
-  - Toast (Announcement / Error)  
+	- Header (Logo / Current User / Setting)  
+	- Main container  
+	- Toast (Announcement / Error)
+
+- **A11y/Device Support**
+	- Tailwind: responsive design (desktop / tablet / mobile)
+	- Input device std support: mouse / keyboard / touch
+		- pointer events API (pointerdown, pointermove, pointerup)
+		- ex): mousedown, touchstart
+
+- **Browser Compatibility**
+	- Firefox(Must) + Chrome(Additional) // Optimazation
 
 - **Routing**  
-  - History API (Forward / Back movement)  
-  - Accessibility: Move focus on navigation  
+	- History API: Forward / Back (pushState / popstate)
+	- Accessibility: Move focus on navigation
 
 ---
 
 ### (1) Init Page  
 - **Path**: `/init`  
 - **AliasForm**  
-  - User ID registration form with validation  
-    - Empty → “Please enter your ID”  
-    - Duplicate → “This ID already exists”  
-    - Length → “Maximum 16 characters allowed”  
-    - Forbidden word → “This ID contains restricted words”  
-  - Submit button enabled only when valid  
+	- User ID registration form with validation  
+		- Empty → “Please enter your ID”  
+		- Duplicate → “This ID already exists”  
+		- Length → “Maximum 16 characters allowed”  
+		- Forbidden word → “This ID contains restricted words”  
+		- Submit button enabled only when valid  
 
 - **On success** → Navigate to Lobby (`/`)  
 
@@ -118,54 +132,79 @@
 ## ✅ Folder Structure
 
 ```
-/src
-├── /app
-│   ├── router/
-│   ├── store/
-│   └── shell/
+./
+├── index.html
 │
-├── /pages
-│   ├── /lobby/
-│   ├── /local/
-│   ├── /tournaments/
-│   ├── /tournament-id/
-│   └── /game/
+├── vite.config.ts
+├── tailwind.config.js
+├── postcss.config.js
 │
-├── /game
-│   ├── state.ts        # GameState, physics params
-│   ├── systems.ts      # updatePhysics, score, reset
-│   └── input.ts        # keyboard mapping
+├── tsconfig.json
+├── package.json
 │
-├── /renderers
-│   ├── canvas2d.ts     # Phase 1
-│   └── babylon.ts      # Phase 3
+├── docker-compose.yml
+├── Dockerfile
 │
-├── /ui
-│   ├── HUD/
-│   ├── ResultModal/
-│   └── buttons/
+├── public/
+│   └── favicon.svg
 │
-└── /services
-    ├── tournament.ts   # tournament data
-    └── matchmaking.ts  # matchmaking mock
+└──	/src
+	├── style.css
+	├── main.ts
+	│
+	├── /app
+	│   ├── router/router.ts
+	│   ├── store/store.ts
+	│   └── shell/guards.ts
+	│
+	├── /pages
+	│   ├── lobby.ts
+	│   ├── local.ts
+	│   ├── tournaments.ts
+	│   ├── tournament-id.ts
+	│   ├── game.ts
+	│   └── not-found.ts
+	│
+	├── /game
+	│   ├── state.ts        # GameState, physics params
+	│   ├── systems.ts      # updatePhysics, score, reset
+	│   └── input.ts        # keyboard mapping
+	│
+	├── /renderers
+	│   ├── canvas2d.ts     # Phase 1
+	│   └── babylon.ts      # Phase 3
+	│
+	├── /ui
+	│   ├── HUD/
+	│   ├── ResultModal/
+	│   └── buttons/
+	│
+	└── /services
+		├── tournament.ts   # tournament data
+		└── matchmaking.ts  # matchmaking mock
 ```
 
 ## ✅ To-Do List (by priority)
 
 ### Phase 0: Scaffolding / Core
 1. **Scaffolding**  
-   - [ ] Init project: Vite + TypeScript + Tailwind  
+   - [✅] Init project: Vite + TypeScript + Tailwind
    - [ ] ESLint / Prettier (strict TypeScript)  
-   - [ ] `public/index.html`: `<main id="app" tabindex="-1">` (a11y focus target)  
+   - [✅] `public/index.html`: `<main id="app" tabindex="-1">` (a11y focus target)
+   - [⏳] Tailwind breakpoints (sm / md / lg), supported on all devices
+   - [⏳] Firefox + chrome // Compatibility
 
 2. **Routing (History API)**  
-   - [ ] Intercept `a[href]` +
-   		- `pushState`
-		- `replaceState`
-		- `popState`
-   - [ ] Focus `#app` on navigation (a11y)  
-   - [ ] Scroll restoration
-   - [ ] 404 handling (History fallback server config)  
+	- [✅] Intercept `a[href]` +
+   		- [✅]`pushState`
+		- [✅]`replaceState`
+		- [✅]`popState`
+	- [✅] Focus `#app` on navigation (a11y)
+	- [✅] Router smoke test
+	- [✅] Scroll restoration
+	- [⏳] 404 handling
+   		- [✅] View page of 404 client (not-found.ts)
+		- [ ] History fallback server config
 
 3. **Core Infra (Store / Guard)**  
    - Global store (observer pattern):  
@@ -261,7 +300,8 @@
 ---
 
 ## 📝 Final Check-list
-- [ ] Page transitions work without full refresh  
+- [ ] Page transitions work without full refresh
 - [ ] Browser forward / back navigation functions correctly  
-- [ ] Compatible with the latest Firefox (tested & polished)  
+- [ ] Compatible with the latest Firefox and chrome (tested & polished) 
+- [ ] Responsive layout (Desktop / Tablet / Mobile)
 - [ ] One-line execution with Docker (`docker compose up`)

--- a/frontend_jason/src/app/router.ts
+++ b/frontend_jason/src/app/router.ts
@@ -1,4 +1,3 @@
-// src/app/router.ts
 // SPA 라우터: URL ↔ 페이지 모듈 매칭, a[href] 인터셉트, popstate 처리, 포커스 이동, 404 처리
 
 type Cleanup = () => void;
@@ -17,16 +16,43 @@ const routes: [RegExp, Importer][] = [
 ];
 
 export function initRouter(root: HTMLElement) {
-  let cleanup: Cleanup | undefined;
+	let cleanup: Cleanup | undefined;
+
+	/*
+		Manually off the browser's basic setting of scroll Restroation
+
+		기본 복원 옵션 꺼주는 이유:
+		1. 일관성:
+			브라우저, 플랫폼마다 자동 복원 타이밍이 달라서 결과가 다르다.
+			manual로 처음부터 꺼버리고 항상 같은 로직 (저장 -> 복원) 사용하면 안정적이다.
+		2. 변화 대응:
+			페이지 전환 후 이미지가 늦게 로드 될 경우 자동복원 시 틀린 위치로 복원될수 있다.
+			직접 복원하면 좀 더 정확하다.
+	*/
+	if ("scrollRestoration" in history) {
+		try { history.scrollRestoration = "manual"; } catch {}
+	}
+
+  // Save current scroll to history.
+  function saveScroll() {
+    const prev = history.state ?? {};
+    try {
+      history.replaceState(
+        { ...prev, scrollX: window.scrollX, scrollY: window.scrollY },
+        "",
+        location.pathname + location.search,
+      );
+    } catch {}
+  }
 
   async function render(path: string) {
-    // 이전 페이지 clean-up
+    // clean-up 'previous page'
     cleanup?.();
 
     const url = new URL(path, location.origin);
     const pathname = url.pathname;
 
-    // 매칭 라우트 찾기
+    // Find matching router.
     const hit = routes.find(([re]) => re.test(pathname));
 	if (!hit) {
       const mod = (await import("../pages/not-found")) as PageModule;
@@ -49,36 +75,59 @@ export function initRouter(root: HTMLElement) {
   }
 
   // 내부 링크 인터셉트 (새탭/중클릭/수정키는 통과)
-  document.addEventListener("click", (e) => {
-    const a = (e.target as HTMLElement).closest?.("a[href]") as HTMLAnchorElement | null;
-    if (!a) return;
+	document.addEventListener("click", (e) => {
+		const a = (e.target as HTMLElement).closest?.("a[href]") as HTMLAnchorElement | null;
+		if (!a) return;
 
-    const me = e as MouseEvent;
-    if (me.defaultPrevented) return;
-    if (me.button !== 0 || me.metaKey || me.ctrlKey || me.shiftKey || me.altKey) return;
+		const me = e as MouseEvent;
+		if (me.defaultPrevented) return;
+		if (me.button !== 0 || me.metaKey || me.ctrlKey || me.shiftKey || me.altKey) return;
 
-    const url = new URL(a.href, location.origin);
-    if (url.origin !== location.origin) return; // 외부 링크는 통과
+		const url = new URL(a.href, location.origin);
+		if (url.origin !== location.origin) return; // 외부 링크는 통과
 
-    const next = url.pathname + url.search;
-    const curr = location.pathname + location.search;
-    if (next === curr) { e.preventDefault(); return; }
+		const next = url.pathname + url.search;
+		const curr = location.pathname + location.search;
+		if (next === curr) { e.preventDefault(); return; }
 
-    e.preventDefault();
-    history.pushState({}, "", next);
-    render(next);
-  });
+		e.preventDefault();
 
-  // 뒤/앞 이동
-  window.addEventListener("popstate", () => {
-    render(location.pathname + location.search);
-  });
+		// Before leaving page, save current scroll
+		saveScroll();	
+
+		// 
+		history.pushState({ scrollX: 0, scrollY: 0 }, "", next);
+		render(next);
+	});
+
+	/*
+		Basic: popstate - move forward, backward
+		= 스크롤의 위치를 별도로 저장해주지 않았기에
+		  스크롤을 내려서 웹페이지 아래쪽에 있다가
+		  back을 누르고 다시 forward를 누를 경우
+		  원래 위치해 있던 스크룰 위치에 도달하는게 아니라
+		  웹의 가장 윗쪽으로 이동해있게 된다.
+	*/
+	// window.addEventListener("popstate", () => {
+	// 	render(location.pathname + location.search);
+	// });
+
+	// popState: move forward & backward
+	// ! AND ! save scroll last position
+	window.addEventListener("popstate", (ev: PopStateEvent) => {
+		render(location.pathname + location.search);
+
+		// 스크롤 복원
+		const s = (ev.state ?? {}) as { scrollX?: number; scrollY?: number };
+		if (typeof s.scrollY === "number") {
+			window.scrollTo(s.scrollX ?? 0, s.scrollY);	// 저장된 스크롤로 복원 (없으면 0,0)
+		}
+	});
 
   	// 전환 후 포커스 (a11y)
+	// 화면 전환 후 브라우저의 포커스를 어디로할지 결정한다.
 	function postRenderFocus() {
-    	document.getElementById("app")?.focus();
-    	// 필요하면 스크롤 정책도 추가
-    	// window.scrollTo({ top: 0 });
+    	document.getElementById("app")?.focus({ preventScroll: true });
 	}
 
 	return { render };
@@ -87,7 +136,37 @@ export function initRouter(root: HTMLElement) {
 // Programatic navigation
 export function navigate(to: string)
 {
-	const next = to.startsWith("/") ? to : "/" + to; // ← startsWith(✅)
-	history.pushState({}, "", next);
+	const next = to.startsWith("/") ? to : "/" + to;
+
+	// 페이지 떠나기 전 현재 스크롤 저장
+	try {
+		const prev = history.state ?? {};
+		history.replaceState(
+			{ ...prev, scrollX: window.scrollX, scrollY: window.scrollY },
+			"",
+			location.pathname + location.search,
+		);
+	} catch {}
+
+	// basic scroll state (맨 위) pops
+	history.pushState({ scrollX: 0, scrollY: 0 }, "", next);
+	dispatchEvent(new PopStateEvent("popstate"));
+}
+
+// replaceState
+export function replace(to: string) {
+	const next = to.startsWith("/") ? to : "/" + to;
+
+	// 떠나기 전 현재 스크롤 저장
+	try {
+    	const prev = history.state ?? {};
+		history.replaceState(
+			{ ...prev, scrollX: window.scrollX, scrollY: window.scrollY },
+      		"",
+      		location.pathname + location.search,
+    	);
+	} catch {}
+
+	history.replaceState({ scrollX: 0, scrollY: 0 }, "", next);
 	dispatchEvent(new PopStateEvent("popstate"));
 }

--- a/frontend_jason/src/main.ts
+++ b/frontend_jason/src/main.ts
@@ -1,11 +1,12 @@
+// Load styles from TailwindCSS
 import "./styles.css";
-import { initRouter, navigate } from "@/app/router";
 
-const root = document.getElementById("app")!;
+// Router setup: History API (f / b) + link interception.
+import { initRouter } from "./app/router";
+
+// Get app's root (main: "app"), start router, render current URL(= home)
+const root = document.querySelector<HTMLElement>("main#app")!;
+if (!root) throw new Error("Root element #app not found");
+
 const { render } = initRouter(root);
-
-// 초기 진입
 render(location.pathname + location.search);
-
-// 데모 링크 (원하면 제거)
-Object.assign(window, { navigate });

--- a/frontend_jason/src/pages/game.ts
+++ b/frontend_jason/src/pages/game.ts
@@ -1,1 +1,10 @@
-export default () => {};
+export default function (root: HTMLElement) {
+  root.innerHTML = `
+    <section class="p-6 space-y-6">
+      <h1 class="text-3xl font-bold">Lobby</h1>
+      <nav class="flex gap-3">
+        <a href="/local" class="px-3 py-2 rounded bg-blue-600 text-white">Local</a>
+        <a href="/tournaments" class="px-3 py-2 rounded bg-indigo-600 text-white">Tournaments</a>
+      </nav>
+    </section>`;
+}

--- a/frontend_jason/src/pages/init.ts
+++ b/frontend_jason/src/pages/init.ts
@@ -1,1 +1,10 @@
-export default () => {};
+export default function (root: HTMLElement) {
+  root.innerHTML = `
+    <section class="p-6 space-y-6">
+      <h1 class="text-3xl font-bold">Lobby</h1>
+      <nav class="flex gap-3">
+        <a href="/local" class="px-3 py-2 rounded bg-blue-600 text-white">Local</a>
+        <a href="/tournaments" class="px-3 py-2 rounded bg-indigo-600 text-white">Tournaments</a>
+      </nav>
+    </section>`;
+}

--- a/frontend_jason/src/pages/lobby.ts
+++ b/frontend_jason/src/pages/lobby.ts
@@ -1,1 +1,10 @@
-export default () => {};
+export default function (root: HTMLElement) {
+  root.innerHTML = `
+    <section class="p-6 space-y-6">
+      <h1 class="text-3xl font-bold">Lobby</h1>
+      <nav class="flex gap-3">
+        <a href="/local" class="px-3 py-2 rounded bg-blue-600 text-white">Local</a>
+        <a href="/tournaments" class="px-3 py-2 rounded bg-indigo-600 text-white">Tournaments</a>
+      </nav>
+    </section>`;
+}

--- a/frontend_jason/src/pages/local.ts
+++ b/frontend_jason/src/pages/local.ts
@@ -1,1 +1,11 @@
-export default () => {};
+export default function (root: HTMLElement) {
+  root.innerHTML = `
+    <section class="p-6 space-y-4">
+      <h2 class="text-2xl font-semibold">Local</h2>
+      <p class="text-gray-600">Button for game start</p>
+      <button class="px-4 py-2 rounded bg-slate-300 text-slate-700 cursor-not-allowed" aria-disabled="true">
+        GameStart (simulate later in phase2)
+      </button>
+      <p class="mt-4"><a href="/" class="underline text-blue-600">← Lobby</a></p>
+    </section>`;
+}

--- a/frontend_jason/src/pages/not-found.ts
+++ b/frontend_jason/src/pages/not-found.ts
@@ -1,1 +1,7 @@
-export default () => {};
+export default function (root: HTMLElement) {
+  root.innerHTML = `
+    <section class="p-6 space-y-4">
+      <h2 class="text-2xl font-semibold">Not Found</h2>
+      <a href="/" class="underline text-blue-600">Go to Lobby</a>
+    </section>`;
+}

--- a/frontend_jason/src/pages/tournament-detail.ts
+++ b/frontend_jason/src/pages/tournament-detail.ts
@@ -1,1 +1,10 @@
-export default () => {};
+export default function (root: HTMLElement) {
+  root.innerHTML = `
+    <section class="p-6 space-y-6">
+      <h1 class="text-3xl font-bold">Lobby</h1>
+      <nav class="flex gap-3">
+        <a href="/local" class="px-3 py-2 rounded bg-blue-600 text-white">Local</a>
+        <a href="/tournaments" class="px-3 py-2 rounded bg-indigo-600 text-white">Tournaments</a>
+      </nav>
+    </section>`;
+}

--- a/frontend_jason/src/pages/tournaments.ts
+++ b/frontend_jason/src/pages/tournaments.ts
@@ -1,1 +1,17 @@
-export default () => {};
+export default function (root: HTMLElement) {
+  root.innerHTML = `
+    <section class="p-6 space-y-6">
+      <h2 class="text-2xl font-semibold">Tournaments</h2>
+      <div class="grid sm:grid-cols-2 gap-4">
+        <article class="rounded border p-4 shadow-sm">
+          <h3 class="font-medium">Summer Open</h3>
+          <p class="text-sm text-gray-500">Dummy card</p>
+        </article>
+        <article class="rounded border p-4 shadow-sm">
+          <h3 class="font-medium">Autumn Cup</h3>
+          <p class="text-sm text-gray-500">Dummy card</p>
+        </article>
+      </div>
+      <p class="mt-4"><a href="/" class="underline text-blue-600">← Lobby</a></p>
+    </section>`;
+}

--- a/frontend_jason/src/style.css
+++ b/frontend_jason/src/style.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/frontend_jason/src/styles.css
+++ b/frontend_jason/src/styles.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* 선택: 전역 커스텀 */
+:root {
+  --app-bg: #0b1020;
+}
+body { background: var(--app-bg); }

--- a/frontend_jason/tailwind.config.js
+++ b/frontend_jason/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
+
 export default {
-  content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx,html}"],
+  content: [
+    "./index.html",
+    "./src/**/*.{ts,tsx,js,jsx,html}"
+  ],
   theme: { extend: {} },
   plugins: [],
-};
+}


### PR DESCRIPTION
- Init Vite + TypeScript + Tailwind (running OK)
- Add <main id="app" tabindex="-1"> as a11y focus target (+ skip link)
- Implement router (page module import)
- Intercept internal a[href]; pushState/replaceState; popstate re-render
- Manual scroll restoration: history.replaceState, popstate
- Focus '#app' after render with preventScroll to avoid jumps
- Add client 404 view (not-found.ts) - dummy
- Add page stubs: lobby, local, tournaments - dummy
- Smoke-tested: internal nav, back/forward, Tab focus