### PR TITLE
feat(core): complete Phase 0(scaffolding, routing, store/guards, UI, pages)

### DIFF
--- a/frontend_jason/readme.md
+++ b/frontend_jason/readme.md
@@ -132,66 +132,68 @@
 ## ✅ Folder Structure
 
 ```
-./
-├── index.html
+./								[ Description ]
+├── index.html					Entry HTML file, root container for the APP.
 │
-├── vite.config.ts
-├── tailwind.config.js
-├── postcss.config.js
+├── vite.config.ts				Vite, is Build tool, config.
+├── tailwind.config.js			TailwindCSS Customization config.
+├── postcss.config.js			PostCss config.
 │
-├── tsconfig.json
-├── package.json
+├── tsconfig.json				Typescript compiler options.
+├── package.json				Project metadata & dependencies.
 │
-├── docker-compose.yml
-├── Dockerfile
+├── docker-compose.yml			Docker multi-server setup.
+├── Dockerfile					Docker build config.
 │
 ├── public/
-│   └── favicon.svg
+│   └── favicon.svg				App icon.
 │
 └──	/src
-	├── style.css
-	├── main.ts
+	├── main.ts					App entry point (router, store, DOM mount).
 	│
-	├── /app
-	│   ├── router/router.ts
-	│   ├── store/store.ts
-	│   └── shell/guards.ts
+	├── style.css				Global styles based on TailwindCSS.
 	│
-	├── /pages
-	│   ├── lobby.ts
-	│   ├── local.ts
-	│   ├── tournaments.ts
-	│   ├── tournament-id.ts
-	│   ├── game.ts
-	│   └── not-found.ts
+	├── /app					[ Core logic ]
+	│   ├── router/router.ts	Set navigations between pages.
+	│   ├── store/store.ts		Temporary storage while the frontend app is running.
+	│   └── shell/guards.ts		Access control rules for pages. (ex: No Id -> No game)
+	│
+	├── /pages					[ Each page view ]
+	│   ├── lobby.ts			Lobby for matchmaking with other players.
+	│   ├── local.ts			Local play screen. (Same computer)
+	│   ├── tournaments.ts		Tournament list.
+	│   ├── tournament-id.ts	Detail description of tournament.
+	│   ├── game.ts				Game rendering page.
+	│   └── not-found.ts		404 error page.
 	│
 	├── /game
-	│   ├── state.ts        # GameState, physics params
-	│   ├── systems.ts      # updatePhysics, score, reset
-	│   └── input.ts        # keyboard mapping
+	│   ├── state.ts			GameState & physics parameters.
+	│   ├── systems.ts			updatePhysics, scoring, reset logic.
+	│   └── input.ts			keyboard input mapping.
 	│
 	├── /renderers
-	│   ├── canvas2d.ts     # Phase 1
-	│   └── babylon.ts      # Phase 3
+	│   ├── canvas2d.ts			# Phase 1: renderer using Canvas2D
+	│   └── babylon.ts			# Phase 3: renderer using Babylon.js
 	│
 	├── /ui
-	│   ├── HUD/
-	│   ├── ResultModal/
-	│   └── buttons/
+	│   ├── HUD/				Heads-up display components.
+	│   ├── ResultModal/		Game result modal window.
+	│   └── buttons/			Reusable button components.
 	│
 	└── /services
-		├── tournament.ts   # tournament data
-		└── matchmaking.ts  # matchmaking mock
+		├── tournament.ts		Tournament data handloing.
+		└── matchmaking.ts		Mock data for matchmaking.
 ```
 
 ## ✅ To-Do List (by priority)
 
 ### Phase 0: Scaffolding / Core
 1. **Scaffolding**  
-   - [✅] Init project: Vite + TypeScript + Tailwind
-   - [✅] ESLint / Prettier (strict TypeScript)  
-   - [✅] `public/index.html`: `<main id="app" tabindex="-1">` (a11y focus target)
-   - [✅] Tailwind breakpoints (sm / md / lg), supported on all devices
+	- [✅] Init project: Vite + TypeScript + Tailwind
+	- [✅] ESLint / Prettier (strict TypeScript)
+	- [✅] `public/index.html`: `<main id="app" tabindex="-1">` (a11y focus target)
+	- [✅] Firefox & chrome : Smoke test // Compatibility (호환성)
+	- [✅] Tailwind breakpoints (sm / md / lg / xl / 2xl), supported on all devices
 		- "Accessibility, Support on all devices" -> breakpoins.
 		- "Must use the TailwindCSS"
 		- pixel size 
@@ -200,51 +202,64 @@
 			- lg: 1024px >=
 			- xl: 1280px >=
 			- 2xl: 1536px >=
-   - [✅] Firefox + chrome // Compatibility
 
 2. **Routing (History API)**  
-	- [✅] Intercept `a[href]` +
-   		- [✅]`pushState`
-		- [✅]`replaceState`
-		- [✅]`popState`
+	- [✅] Intercept
+		- [✅] `a[href]`
+   		- [✅] `pushState`
+		- [✅] `replaceState`
+		- [✅] `popState`
 	- [✅] Focus `#app` on navigation (a11y)
-	- [✅] Router smoke test
+	- [✅] Router: Smoke test
 	- [✅] Scroll restoration
-	- [⏳] 404 handling
-   		- [✅] View page of 404 client (not-found.ts)
-		- [🔺] History fallback server config
-			```
-			(Not fixed alone, must be with Backend side)
-			The router handles 404 views on the client side,
-			but for direct access or refresh at deep URLs
-			(ex: /game/123)
+	- [✅] Client 404 error page view (not-found.ts)
+	- [🔺] 404 Server history fallback
+		```
+		(Not fixed alone, must be with Backend side)
+		The router handles 404 views on the client side,
+		but for direct access or refresh at deep URLs
+		(ex: /game/123)
 			
-			the server currently returns a server 404.
-			To fix this, the server needs to always return index.html for unknown routes, so the client-side router can take over.
-			```
+		the server currently returns a server 404.
+		To fix this, the server needs to always return index.html for unknown routes,
+		so the client-side router can take over.
+		```
 
 3. **Core Infra (Store / Guard)**  
-   - Global store (observer pattern):  
-     - auth / alias, tournament, match  
-   - Guards:  
-     - `/game/:matchId`:  
-       - Local → Only matchIds issued from `/local`
-       - Tournament → Allowed only if `MyMatch.status === "ready"`  
+	- [✅] Global store
+		- [✅] alias (session.alias, setAlias)
+		- [✅] tournament (tournament.currentId, setTournamentId)
+		- [✅] match/myMatch (assignMyTournamentMatch, setMyMatchStatus)
+		- [✅] Save session (sessionStorage)
+	- [✅]Guards
+		- [✅]`/game/:matchId`: 
+		- [✅] Local → Only matchIds issued from `/local` (based on last local)
+		- [✅] Tournament → Allowed only if `MyMatch.status === "ready || playing"`
 
-4. **AppShell + Page Stubs** (6 routes + 404)  
-   - `/`: Lobby with 2 buttons (Local / Tournament)  
-   - `/local`: GameStartButton → `local-<timestamp>` → `/game/:id`  
-   - `/tournaments`: Dummy cards with “Enter”  
-   - `/tournaments/:id`: Header + BracketView + MyMatch + Announcements + AliasGate  
-   - `/game/:matchId`: Placeholder (Canvas + HUD slots)  
-   - `/*`: 404 Page with “Back to Lobby”  
+4. **AppShell + Page Stubs (6 routes + 404)**
+	- [✅] `/`: Lobby with 2 buttons (Local / Tournament)  
+	- [✅] `/local`: GameStartButton → `Start Local Match` → `local-<timestamp>` → `/game/:id`  
+	- [✅] `/tournaments`: Dummy cards with “Enter”  + Demo link
+	- [✅] `/tournaments/:id`: Header + AliasGate + MyMatch + BracketView + Announcements stub
+	- [✅] `/game/:matchId`: Placeholder (Canvas + HUD slots)
+		- Canvas: Digital paper, to render game graphic.
+		- HUD: Heads-Up Display = UI Windows to overlay over canvas for score, time, ...
+	- [✅] `/*`: 404 Page with “Back to Lobby”
+
+5. **Auth (Mock for current process, real auth after Phase 1)**
+	- [] Add **mock auth** (login / logout) to unblock guarded routes
+	- [] Add **protected route** `profile` (redirects to `auth?next=...` when not signed it)
+	- [] **Adapter swap point** `src/app./auth.ts`
+		- For now it re-exports mock
+		- Later replace with real API ('real-auth.ts`) **after Phase 1**
 
 ### Definition of Done (DoD)
-- [ ] Forward / back navigation works  
-- [ ] Focus moves to `#app` on route change  
-- [ ] Local flow: `/local → /game/:id` works with generated matchId  
-- [ ] Tournament flow: `/tournaments/:id → AliasGate` visible correctly  
-- [ ] 404 works with redirect  
+- [✅] Forward / back navigation works  
+- [✅] Focus moves to `#app` on route change  
+- [✅] Local flow: `/local → /game/:id` works with generated matchId  
+- [✅] Tournament flow: `/tournaments/:id → AliasGate` visible correctly
+	- assignPending, setReady, setPlaying
+- [🔺] 404 works with redirect // waiting backend side
 
 ---
 

--- a/frontend_jason/src/app/guards.ts
+++ b/frontend_jason/src/app/guards.ts
@@ -1,0 +1,33 @@
+// Route guards for navigation decisions
+// ex: No ID ? -> No Game !
+import { getState } from "./store";
+
+type GuardResult =
+	| { ok: true }
+	| { ok: false; redirect: string; reason: string };
+
+export function canEnterGame(matchId: string): GuardResult {
+	const s = getState();
+	const m = s.myMatch;
+
+	// Local rule: only the last local match created from /local is allowed
+	if (matchId.startsWith("local-")) {
+		if (s.session.lastLocalMatchId === matchId)
+			return { ok: true };
+		return { ok: false, redirect: "/local", reason: "invalid-local-match" };
+	}
+
+	// Tournament rule: must be the user's assigned match AND status is ready/playing
+	if (m?.type === "tournament" && m.id === matchId) {
+		if (m.status === "ready" || m.status === "playing")
+			return { ok: true };
+		return {
+			ok: false,
+			redirect: `/tournaments/${m.tournamentId ?? ""}`,
+			reason: `match-${m.status}`,
+		};
+	}
+
+	// Unknown match id
+	return { ok: false, redirect: "/", reason: "no-match-bound" };
+}

--- a/frontend_jason/src/app/store.ts
+++ b/frontend_jason/src/app/store.ts
@@ -1,0 +1,98 @@
+// Global store (observer pattern) for alias/session, tournament, and myMatch.
+export type MatchType = "local" | "tournament";
+export type MatchStatus = "pending" | "ready" | "playing" | "finished";
+
+export interface MyMatch {
+	id: string;
+	type: MatchType;
+	status: MatchStatus;
+	tournamentId?: string;
+}
+
+export interface State {
+	session: {
+		alias?: string;
+		lastLocalMatchId?: string;
+	};
+
+	tournament: {
+		currentId?: string;
+	};
+
+	myMatch?: MyMatch;
+}
+
+type Listener = (s: State) => void;
+
+const STORAGE_KEY = "ft_transcendence_version1";
+
+function load(): State | undefined {
+	try {
+		const raw = sessionStorage.getItem(STORAGE_KEY);
+		return raw ? (JSON.parse(raw) as State) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function save(s: State) {
+	try {
+		sessionStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+	} catch {}
+}
+
+const state: State = load() ?? { session: {}, tournament: {} };
+
+const listeners = new Set<Listener>();
+
+function emit() {
+	save(state);
+	for (const fn of listeners) fn(state);
+}
+
+export function subscribe(fn: Listener) {
+	listeners.add(fn);
+	return () => listeners.delete(fn);
+}
+
+export function getState(): State {
+	return state;
+}
+
+// --- Session / Alias ---
+export function setAlias(alias: string) {
+	state.session.alias = alias.trim() || undefined;
+	emit();
+}
+
+// --- Local match helpers ---
+export function startLocalMatch(): string {
+	const id = `local-${Date.now()}`;
+	state.session.lastLocalMatchId = id;
+	state.myMatch = { id, type: "local", status: "ready" };
+	emit();
+	return id;
+}
+
+// --- Tournament helpers (stubs to be used by tournament pages) ---
+export function setTournamentId(tournamentId: string) {
+	state.tournament.currentId = tournamentId;
+	emit();
+}
+
+export function assignMyTournamentMatch(matchId: string, status: MatchStatus = "pending") {
+	state.myMatch = {
+		id: matchId,
+		type: "tournament",
+		status,
+		tournamentId: state.tournament.currentId,
+	};
+	emit();
+}
+
+export function setMyMatchStatus(status: MatchStatus) {
+	if (!state.myMatch)
+		return;
+	state.myMatch.status = status;
+	emit();
+}

--- a/frontend_jason/src/pages/game.ts
+++ b/frontend_jason/src/pages/game.ts
@@ -1,10 +1,15 @@
 export default function (root: HTMLElement) {
 	root.innerHTML = `
-		<section class="py-6 md:py-8 lg:py-10 space-y-6">
+		<section class="py-6 md:py-8 lg:py-10 space-y-4">
 			<h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold">Game</h1>
-			<nav class="flex flex-col sm:flex-row gap-2 sm:gap-3">
-				<a href="/local" class="w-full sm:w-auto px-4 py-2 rounded bg-blue-600 text-white text-center">Local</a>
-				<a href="/tournaments" class="w-full sm:w-auto px-4 py-2 rounded bg-indigo-600 text-white text-center">Tournaments</a>
-			</nav>
+			
+			<!-- Canvas placeholder -->
+			<canvas id="gameCanvas" width="800" height="450" class="w-full max-w-full border rounded"></canvas>
+
+			<!-- HUD slots placeholder -->
+			<div id="hud" class="grid grid-cols-2 gap-3 text-sm">
+				<div class="rounded border p-3">HUD: Score</div>
+				<div class="rounded border p-3">HUD: Controls</div>
+			</div>
 		</section>`;
 }

--- a/frontend_jason/src/pages/lobby.ts
+++ b/frontend_jason/src/pages/lobby.ts
@@ -1,14 +1,3 @@
-// export default function (root: HTMLElement) {
-// 	root.innerHTML = `
-// 		<section class="py-6 md:py-8 lg:py-10 space-y-6">
-// 			<h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold">Lobby</h1>
-// 			<nav class="flex flex-col sm:flex-row gap-2 sm:gap-3">
-// 				<a href="/local" class="w-full sm:w-auto px-4 py-2 rounded bg-blue-600 text-white text-center">Local</a>
-// 				<a href="/tournaments" class="w-full sm:w-auto px-4 py-2 rounded bg-indigo-600 text-white text-center">Tournaments</a>
-// 			</nav>
-// 		</section>`;
-// }
-
 export default function (root: HTMLElement) {
 	root.innerHTML = `
 	<section class="py-6 md:py-8 lg:py-10 space-y-8">

--- a/frontend_jason/src/pages/local.ts
+++ b/frontend_jason/src/pages/local.ts
@@ -1,11 +1,27 @@
+import { startLocalMatch } from "@/app/store";
+import { navigate } from "@/app/router";
+
 export default function (root: HTMLElement) {
 	root.innerHTML = `
 		<section class="py-6 md:py-8 lg:py-10 space-y-4">
 			<h2 class="text-xl sm:text-2xl lg:text-3xl font-semibold">Local</h2>
 			<p class="text-gray-600">Button for game start</p>
-			<button class="w-full sm:w-auto px-4 py-2 rounded bg-slate-300 text-slate-700 cursor-not-allowed" aria-disabled="true">
-				GameStart (simulate later in phase2)
+
+			<!-- Specific ID + Simulator button -->
+			<button id="startLocal"
+					class="w-full sm:w-auto px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+				Start Local Match
 			</button>
+
 			<p class="mt-4"><a href="/" class="underline text-blue-600">← Lobby</a></p>
 		</section>`;
+
+	// Event
+	root.addEventListener("click", (ev) => {
+		const btn = (ev.target as HTMLElement).closest("#startLocal") as HTMLButtonElement | null;
+		if (!btn)
+			return;
+		const id = startLocalMatch();	// e.g., local-1727600000000
+		navigate(`/game/${id}`);		// Guard will allow only this ID
+	});
 }

--- a/frontend_jason/src/pages/tournament-detail.ts
+++ b/frontend_jason/src/pages/tournament-detail.ts
@@ -1,10 +1,108 @@
-export default function (root: HTMLElement) {
+import { navigate } from "@/app/router";
+import { setAlias, setTournamentId, assignMyTournamentMatch, setMyMatchStatus, getState, subscribe } from "@/app/store";
+
+export default function (root: HTMLElement, ctx: { params?: { id?: string } }) {
+	const tid = ctx.params?.id ?? "t-unknown";
+	setTournamentId(tid);
+
+	const s = getState();
+	const alias = s.session.alias;
+
 	root.innerHTML = `
-		<section class="py-6 md:py-8 lg:py-10 space-y-6">
-			<h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold">Tournament details</h1>
-			<nav class="flex flex-col sm:flex-row gap-2 sm:gap-3">
-				<a href="/local" class="w-full sm:w-auto px-4 py-2 rounded bg-blue-600 text-white text-center">Local</a>
-				<a href="/tournaments" class="w-full sm:w-auto px-4 py-2 rounded bg-indigo-600 text-white text-center">Tournaments</a>
-			</nav>
-		</section>`;
+	<section class="py-6 md:py-8 lg:py-10 space-y-6">
+		<h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold">Tournament ${tid}</h1>
+
+		<div class="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-3">
+			<button id="goGame"
+				class="w-full sm:w-auto
+						px-4 sm:px-5 lg:px-6
+						py-2 sm:py-2.5 lg:py-3
+						text-sm sm:text-base lg:text-lg
+						rounded bg-gray-800 text-white
+						hover:bg-gray-900
+						focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+				Go to my game
+			</button>
+
+			<p id="statusLine"
+				class="text-xs sm:text-sm lg:text-base text-gray-600">
+			</p>
+		</div>
+
+		<div class="rounded border p-4 space-y-3">
+			<h2 class="font-semibold">Alias</h2>
+			<form id="aliasForm" class="flex gap-2 items-center">
+				<input id="aliasInput" class="border rounded px-3 py-2 w-full sm:w-64" placeholder="Enter alias" value="${alias ?? ""}" />
+				<button class="px-3 py-2 rounded bg-indigo-600 text-white">Save</button>
+			</form>
+			<p class="text-sm text-gray-600">Alias is required to receive your match.</p>
+		</div>
+
+		<div class="rounded border p-4 space-y-3">
+			<h2 class="font-semibold">My Match</h2>
+			<div class="flex flex-wrap gap-2">
+				<button id="assignPending" class="px-3 py-2 rounded bg-slate-200">Assign (pending)</button>
+				<button id="setReady" class="px-3 py-2 rounded bg-emerald-600 text-white">Set Ready</button>
+				<button id="setPlaying" class="px-3 py-2 rounded bg-blue-600 text-white">Set Playing</button>
+			</div>
+			<p class="text-sm text-gray-600">Use these to simulate a real tournament backend.</p>
+		</div>
+
+		<section class="rounded border p-4"><h2 class="font-semibold">BracketView (stub)</h2></section>
+		<section class="rounded border p-4"><h2 class="font-semibold">Announcements (stub)</h2></section>
+
+		<p class="mt-4"><a href="/tournaments" class="underline text-blue-600">← Tournaments</a></p>
+	</section>`;
+
+	// Status HUD
+	// "Go to my game"
+	const goBtn = root.querySelector<HTMLButtonElement>("#goGame")!;
+	const statusLine = root.querySelector<HTMLElement>("#statusLine")!;
+	function renderStatus() {
+		const s = getState().myMatch;
+		statusLine.textContent = `Status: ${s?.status ?? "none"} (id: ${s?.id ?? "-"})`;
+	}
+
+	renderStatus();
+	const unsubscribe = subscribe(renderStatus);	// Keep the status in unsubscribe for clear finally.
+
+	goBtn.addEventListener("click", () => {
+		const m = getState().myMatch;
+		if (!m)
+			return alert("No match assigned yet.");
+		if (m.status === "ready" || m.status === "playing")
+			navigate(`/game/${m.id}`);
+		else
+			alert(`Match not ready (status=${m.status}).`);
+	});
+
+	// Alias gate
+	const form = root.querySelector<HTMLFormElement>("#aliasForm")!;
+	form.addEventListener("submit", (e) => {
+		e.preventDefault();
+		const val = (root.querySelector<HTMLInputElement>("#aliasInput")!.value || "").trim();
+		setAlias(val);
+	});
+
+	// Simulate receiving a match from backend
+	const pendingBtn = root.querySelector<HTMLButtonElement>("#assignPending")!;
+	pendingBtn.addEventListener("click", () => {
+		const fakeMatchId = `tmatch-${Date.now()}`;
+		assignMyTournamentMatch(fakeMatchId, "pending"); // guard: not allowed yet
+		alert(`Assigned match: ${fakeMatchId} (status=pending)`);
+	});
+
+	root.querySelector<HTMLButtonElement>("#setReady")!.addEventListener("click", () => {
+		setMyMatchStatus("ready"); // guard will allow /game/:id now
+		alert("My match is now READY");
+	});
+
+	root.querySelector<HTMLButtonElement>("#setPlaying")!.addEventListener("click", () => {
+		setMyMatchStatus("playing");
+		alert("My match is now PLAYING");
+	});
+
+	return () => {
+		unsubscribe();
+	}
 }

--- a/frontend_jason/src/pages/tournaments.ts
+++ b/frontend_jason/src/pages/tournaments.ts
@@ -1,17 +1,39 @@
 export default function (root: HTMLElement) {
 	root.innerHTML = `
 		<section class="py-6 md:py-8 lg:py-10 space-y-6">
-			<h2 class="text-xl sm:text-2xl lg:text-3xl font-semibold">Tournaments</h2>
-			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				<article class="rounded border p-4 shadow-sm">
-					<h3 class="font-medium text-lg sm:text-xl">Summer Open</h3>
-					<p class="text-sm sm:text-base text-gray-500">Dummy card</p>
-				</article>
-				<article class="rounded border p-4 shadow-sm">
-					<h3 class="font-medium text-lg sm:text-xl">Autumn Cup</h3>
-					<p class="text-sm sm:text-base text-gray-500">Dummy card</p>
-				</article>
+			<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+				<h2 class="text-xl sm:text-2xl lg:text-3xl font-semibold">Tournaments</h2>
+
+				<a href="/tournaments/demo"
+					class="w-full sm:w-auto inline-flex items-center justify-center px-4 py-2 rounded bg-emerald-600 text-white text-center hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+					Open Demo Tournament
+				</a>
 			</div>
+
+			<!-- All cards are link -->
+			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				<a href="/tournaments/summer-open"
+					class="block rounded border p-4 shadow-sm space-y-2 hover:shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+					<h3 class="font-medium text-lg sm:text-xl">Summer Open</h3>
+					<p class="text-sm sm:text-base text-gray-500">Classic summer series</p>
+					<span class="inline-block mt-2 px-3 py-2 rounded bg-blue-600 text-white">Enter</span>
+				</a>
+
+				<a href="/tournaments/autumn-cup"
+					class="block rounded border p-4 shadow-sm space-y-2 hover:shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+					<h3 class="font-medium text-lg sm:text-xl">Autumn Cup</h3>
+					<p class="text-sm sm:text-base text-gray-500">Pre-season warm-up</p>
+					<span class="inline-block mt-2 px-3 py-2 rounded bg-indigo-600 text-white">Enter</span>
+				</a>
+
+				<a href="/tournaments/demo"
+					class="block rounded border p-4 shadow-sm space-y-2 hover:shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+					<h3 class="font-medium text-lg sm:text-xl">Demo Tournament</h3>
+					<p class="text-sm sm:text-base text-gray-500">Use this to test AliasGate & Guards</p>
+					<span class="inline-block mt-2 px-3 py-2 rounded bg-slate-800 text-white">Enter Demo</span>
+				</a>
+			</div>
+			
 			<p class="mt-4"><a href="/" class="underline text-blue-600">← Lobby</a></p>
-		</section>`;
+    	</section>`;
 }


### PR DESCRIPTION
Highlights
- Tailwind breakpoints (sm/md/lg/xl/2xl) applied; mobile-first responsive layout
- Cross-browser smoke test: Chrome + Firefox
- A11y: skip link, focus-visible styling, focus #app after navigation

Routing (History API)
- Intercept internal a[href] clicks (new tab / modifier keys respected)
- pushState / replaceState / popstate wired
- Manual scrollRestoration + save/restore scroll via history.state
- Dynamic route table with code-splitting:
  - /, /init, /local, /tournaments, /tournaments/:id, /game/:id
- Client 404 view (not-found.ts)

Store & Guards
- sessionStorage persistence (key: ft_transcendence_version1)
- session/alias, tournament.currentId, myMatch state
- APIs: setAlias, setTournamentId, startLocalMatch, assignMyTournamentMatch, setMyMatchStatus, subscribe
- Guards for /game/:matchId:
  - Local: only the last issued local-* id is allowed
  - Tournament: allowed only when myMatch.status ∈ {ready, playing}

Pages
- / (Lobby): responsive nav/buttons
- /local: “Start Local Match” → creates local-<ts> → navigates to /game/:id
- /tournaments: cards (links) + “Open Demo Tournament” link
- /tournaments/:id (tournament-detail):
  - AliasGate (save alias)
  - MyMatch controls: Assign(pending), Set Ready, Set Playing
  - Status line + “Go to my game” button
  - BracketView (stub), Announcements (stub)
- /game/:matchId: Canvas placeholder (#gameCanvas) + HUD slots (#hud)
- /*: 404 page with “Back to Lobby”